### PR TITLE
Deleted to error code from the payment tab

### DIFF
--- a/app/views/6-0/payment-errors.html
+++ b/app/views/6-0/payment-errors.html
@@ -302,6 +302,25 @@
 
     </div>
 
+    <!--- SUSPEND TIMELINE -->
+    <div class="govuk-grid-column-one-third">
+        {% if data['paymentTimelineArray'] %}<h2 class="govuk-heading-m">Payment changes</h2>{% endif %}
+        <div class="dwp-timeline">
+          <ol class="dwp-timeline__items">
+            {% for event in data['paymentTimelineArray'] %}
+                <li class="dwp-timeline__item">
+                <p class="dwp-timeline__datetime">{{event.date | govukDateTime}}</p>
+                <h2 class="dwp-timeline__heading">{{event.title}}</h2>
+                <p class="dwp-timeline__by-line">by {{event.person}}</p>
+                {% if event.reason %}
+                <a href="payment-suspend-details?index={{loop.index0}}&successBanner=false" class="dwp-timeline__link">View details<span class="govuk-visually-hidden"> of the event on </span></a>
+                {% endif %}
+                </li>
+            {% endfor %}
+          </ol>
+        </div>
+    </div>
+    <!--- END OF SUSPEND TIMELINE -->
 
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">Payment history</h2>


### PR DESCRIPTION
I have deleted the timeline code from the payment tab (put in by Mark), as this was causing errors and I need to be able to access this page. I have created another page called payment-errors where Mark can see his original code when he's back to work to fix it.